### PR TITLE
Remove iOS PWA assets to avoid binary files

### DIFF
--- a/hdr-lab/index.html
+++ b/hdr-lab/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>HDR Effects Lab</title>
+  <meta name="theme-color" content="#05060a">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="hero">
+    <p class="tag">Mobile Lab</p>
+    <h1>HDR Experiment Playground</h1>
+    <p class="lede">Compare SDR and HDR-inspired colors, gradients, and the infamous bright QR test. View on an HDR capable device for the full effect.</p>
+    <a class="cta" href="../index.html">Back home</a>
+  </header>
+  <main>
+    <section class="card">
+      <h2>Wide Gamut Swatches</h2>
+      <p>These chips use <code>color(display-p3)</code> values. Devices limited to sRGB will clamp them, while HDR screens should glow.</p>
+      <div class="swatches">
+        <div class="swatch" data-label="Solar Flare"></div>
+        <div class="swatch" data-label="Neo Magenta"></div>
+        <div class="swatch" data-label="Ion Green"></div>
+      </div>
+    </section>
+    <section class="card">
+      <h2>HDR Gradient</h2>
+      <p>The gradient below blends multiple wide gamut stops using <code>color-mix()</code>. Toggle between SDR and HDR references.</p>
+      <div class="gradient-panel">
+        <label class="toggle">
+          <input type="checkbox" id="mode-toggle" aria-label="Toggle HDR preview">
+          <span>HDR Preview</span>
+        </label>
+        <div class="gradient gradient--sdr" aria-hidden="true"></div>
+      </div>
+    </section>
+    <section class="card">
+      <h2>HDR QR Prototype</h2>
+      <p>The famous HDR QR code pushes contrast and saturation beyond SDR. This simplified recreation uses neon hues alongside deep blacks.</p>
+      <figure class="qr">
+        <img src="qr.svg" width="220" height="220" alt="Experimental HDR QR code">
+        <figcaption>Try scanning in a dark room on an HDR display.</figcaption>
+      </figure>
+    </section>
+  </main>
+  <footer>
+    <p>Tip: open the page in Safari on an iPhone 15 Pro or any HDR Android flagship and compare with an SDR device.</p>
+  </footer>
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/hdr-lab/qr.svg
+++ b/hdr-lab/qr.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 220" role="img">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="color(display-p3 1 0.4 0.1)" />
+      <stop offset="100%" stop-color="color(display-p3 0.7 0 1)" />
+    </linearGradient>
+    <linearGradient id="qr" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="color(display-p3 0.2 1 0.5)" />
+      <stop offset="100%" stop-color="color(display-p3 0 0.9 1)" />
+    </linearGradient>
+  </defs>
+  <rect width="220" height="220" rx="24" fill="url(#bg)" />
+  <g fill="#05060a" opacity="0.24">
+    <circle cx="190" cy="30" r="10" />
+    <circle cx="30" cy="190" r="12" />
+  </g>
+  <g fill="url(#qr)">
+    <rect x="20" y="20" width="60" height="60" rx="12" />
+    <rect x="140" y="20" width="60" height="60" rx="12" />
+    <rect x="20" y="140" width="60" height="60" rx="12" />
+  </g>
+  <g fill="#05060a">
+    <rect x="36" y="36" width="28" height="28" rx="6" />
+    <rect x="156" y="36" width="28" height="28" rx="6" />
+    <rect x="36" y="156" width="28" height="28" rx="6" />
+  </g>
+  <g fill="url(#qr)">
+    <rect x="100" y="20" width="20" height="20" rx="4" />
+    <rect x="120" y="60" width="20" height="20" rx="4" />
+    <rect x="80" y="60" width="20" height="20" rx="4" />
+    <rect x="100" y="100" width="20" height="20" rx="4" />
+    <rect x="120" y="120" width="20" height="20" rx="4" />
+    <rect x="80" y="140" width="20" height="20" rx="4" />
+    <rect x="100" y="160" width="20" height="20" rx="4" />
+    <rect x="140" y="140" width="20" height="20" rx="4" />
+    <rect x="160" y="100" width="20" height="20" rx="4" />
+    <rect x="40" y="100" width="20" height="20" rx="4" />
+    <rect x="60" y="120" width="20" height="20" rx="4" />
+    <rect x="120" y="180" width="20" height="20" rx="4" />
+    <rect x="160" y="180" width="20" height="20" rx="4" />
+    <rect x="180" y="160" width="20" height="20" rx="4" />
+  </g>
+</svg>

--- a/hdr-lab/script.js
+++ b/hdr-lab/script.js
@@ -1,0 +1,12 @@
+const toggle = document.getElementById('mode-toggle');
+const gradient = document.querySelector('.gradient');
+
+if (toggle && gradient) {
+  const updateMode = () => {
+    gradient.classList.toggle('gradient--hdr', toggle.checked);
+    gradient.classList.toggle('gradient--sdr', !toggle.checked);
+  };
+
+  toggle.addEventListener('change', updateMode);
+  updateMode();
+}

--- a/hdr-lab/styles.css
+++ b/hdr-lab/styles.css
@@ -1,0 +1,259 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+
+:root {
+  color-scheme: dark;
+  --bg: #05060a;
+  --fg: #f7f8fe;
+  --muted: #a0a4c2;
+  --accent: #ffb347;
+  --shadow: 0 40px 120px rgba(10, 12, 20, 0.6);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: radial-gradient(circle at top, rgba(255, 110, 60, 0.12), transparent 55%), var(--bg);
+  color: var(--fg);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  padding: max(3rem, env(safe-area-inset-top)) 1.25rem 3.5rem;
+}
+
+.hero {
+  display: grid;
+  gap: 1rem;
+  text-align: center;
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.tag {
+  font-size: 0.75rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+h1 {
+  font-size: clamp(2.5rem, 8vw, 3.6rem);
+  margin: 0;
+}
+
+.lede {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.cta {
+  justify-self: center;
+  padding: 0.85rem 1.6rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--accent), color(display-p3 1 0.24 0));
+  color: #120709;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 24px 48px rgba(255, 179, 71, 0.35);
+}
+
+main {
+  display: grid;
+  gap: 2rem;
+  max-width: 960px;
+  margin: 0 auto;
+  width: min(100%, 960px);
+}
+
+.card {
+  padding: 1.75rem;
+  border-radius: 28px;
+  background: rgba(14, 16, 28, 0.75);
+  backdrop-filter: blur(26px);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 1.4rem;
+}
+
+.card h2 {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.card p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.swatches {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.swatch {
+  position: relative;
+  border-radius: 20px;
+  height: 120px;
+  background: linear-gradient(135deg, color(display-p3 1 0.3 0), color(display-p3 1 0.6 0.1));
+  box-shadow: 0 25px 45px rgba(255, 96, 48, 0.4);
+}
+
+.swatch:nth-child(2) {
+  background: linear-gradient(135deg, color(display-p3 0.8 0 0.9), color(display-p3 1 0.2 0.6));
+  box-shadow: 0 25px 45px rgba(255, 0, 170, 0.4);
+}
+
+.swatch:nth-child(3) {
+  background: linear-gradient(135deg, color(display-p3 0.1 1 0.4), color(display-p3 0.2 0.8 0.7));
+  box-shadow: 0 25px 45px rgba(0, 255, 170, 0.35);
+}
+
+.swatch::after {
+  content: attr(data-label);
+  position: absolute;
+  inset: auto 1.2rem 1rem 1.2rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.gradient-panel {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}
+
+.toggle input {
+  width: 48px;
+  height: 28px;
+  border-radius: 999px;
+  position: relative;
+  appearance: none;
+  background: rgba(255, 255, 255, 0.12);
+  outline: none;
+  cursor: pointer;
+  transition: background 0.25s ease;
+}
+
+.toggle input::after {
+  content: '';
+  position: absolute;
+  inset: 4px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, color(display-p3 1 0.5 0), color(display-p3 1 0.1 0.8));
+  transition: transform 0.25s ease;
+}
+
+.toggle input:checked {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.toggle input:checked::after {
+  transform: translateX(20px);
+}
+
+.gradient {
+  --stop-1: #ff6b1a;
+  --stop-2: #e62089;
+  --stop-3: #1cb5e0;
+  --stop-4: #6b2cff;
+  --glow: rgba(255, 188, 74, 0.75);
+  --flare: rgba(246, 72, 196, 0.35);
+  border-radius: 28px;
+  height: 220px;
+  background: linear-gradient(135deg, var(--stop-1), var(--stop-2) 35%, var(--stop-3) 65%, var(--stop-4));
+  filter: saturate(1.15);
+  position: relative;
+  overflow: hidden;
+}
+
+.gradient::before {
+  content: '';
+  position: absolute;
+  inset: 15% 20%;
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--glow), transparent 65%);
+  mix-blend-mode: screen;
+  opacity: 0.85;
+}
+
+.gradient::after {
+  content: '';
+  position: absolute;
+  inset: 25% 40% 15% 15%;
+  border-radius: 36px;
+  background: var(--flare);
+  filter: blur(40px);
+}
+
+.gradient--sdr {
+  filter: saturate(1.05);
+}
+
+.gradient--hdr {
+  --stop-1: color(display-p3 1 0.35 0.05);
+  --stop-2: color(display-p3 0.95 0 0.55);
+  --stop-3: color(display-p3 0.2 0.92 1);
+  --stop-4: color(display-p3 0.6 0.2 1);
+  --glow: color(display-p3 1 0.8 0.2 / 0.88);
+  --flare: color(display-p3 1 0.2 0.75 / 0.55);
+  filter: saturate(1.35) brightness(1.05);
+}
+
+.qr {
+  justify-self: center;
+  text-align: center;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.qr img {
+  width: min(70vw, 220px);
+  height: auto;
+  border-radius: 18px;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.55);
+}
+
+figcaption {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+footer {
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.95rem;
+  margin-bottom: 1rem;
+}
+
+@supports not (color: color(display-p3 1 0 0)) {
+  body::after {
+    content: 'Your display does not support wide-gamut colors. Expect more muted hues.';
+    position: fixed;
+    inset: auto 0 0 0;
+    background: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    padding: 0.75rem 1.25rem;
+    text-align: center;
+    font-size: 0.85rem;
+  }
+}
+
+@media (min-width: 768px) {
+  body {
+    padding: max(4rem, env(safe-area-inset-top)) 2.5rem 4.5rem;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,10 +1,131 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>Hello World</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>hybv.github.io Experiments</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      color-scheme: dark light;
+      --bg: #070910;
+      --card: rgba(18, 22, 36, 0.75);
+      --text: #f6f7ff;
+      --muted: #a5accd;
+      --accent: #7cf9c2;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: "Space Grotesk", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: radial-gradient(circle at top, rgba(124, 249, 194, 0.18), transparent 60%), var(--bg);
+      color: var(--text);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: max(4rem, env(safe-area-inset-top)) 1.75rem 3rem;
+      gap: 2rem;
+    }
+
+    header {
+      text-align: center;
+      max-width: 640px;
+      display: grid;
+      gap: 1rem;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(2.8rem, 7vw, 3.8rem);
+    }
+
+    p {
+      margin: 0;
+      line-height: 1.6;
+      color: var(--muted);
+    }
+
+    .grid {
+      display: grid;
+      gap: 1.5rem;
+      width: min(960px, 100%);
+    }
+
+    .card {
+      padding: 1.75rem;
+      border-radius: 26px;
+      background: var(--card);
+      backdrop-filter: blur(18px);
+      box-shadow: 0 40px 90px rgba(0, 0, 0, 0.45);
+      display: grid;
+      gap: 0.9rem;
+      text-decoration: none;
+      color: inherit;
+      transition: transform 0.25s ease, box-shadow 0.25s ease;
+    }
+
+    .card:hover,
+    .card:focus-visible {
+      transform: translateY(-6px);
+      box-shadow: 0 50px 110px rgba(0, 0, 0, 0.55);
+    }
+
+    .card span {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+      color: var(--accent);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      font-size: 0.75rem;
+    }
+
+    .card h2 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+
+    footer {
+      margin-top: auto;
+      color: var(--muted);
+      font-size: 0.9rem;
+      text-align: center;
+    }
+
+    @media (min-width: 720px) {
+      .grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+    }
+  </style>
 </head>
 <body>
-  Hello World
+  <header>
+    <h1>Mobile Web Experiments</h1>
+    <p>A collection of playful demos for GitHub Pages: scroll interactions and HDR color studies built for modern devices.</p>
+  </header>
+  <div class="grid">
+    <a class="card" href="scrolltest/">
+      <span>Prototype</span>
+      <h2>Scroll Test Playground</h2>
+      <p>Creative CSS scroll effects with parallax layers, sticky storytelling, and animated gradients tuned for touch.</p>
+    </a>
+    <a class="card" href="hdr-lab/">
+      <span>Color Lab</span>
+      <h2>HDR Effects Lab</h2>
+      <p>Test wide-gamut swatches, HDR gradients, and a neon QR prototype on capable displays.</p>
+    </a>
+  </div>
+  <footer>
+    <p>Deploys automatically with GitHub Pages.</p>
+  </footer>
 </body>
 </html>

--- a/scrolltest/index.html
+++ b/scrolltest/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Scroll Experiments</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="progress"></div>
+  <header class="hero">
+    <div class="hero__content">
+      <p class="eyebrow">Interactive Demo</p>
+      <h1>Creative Mobile Scroll Effects</h1>
+      <p class="lede">Swipe through to explore layered parallax, sticky storytelling, and color drenched reveals built entirely with modern CSS.</p>
+      <a class="cta" href="#snap-tour">Start the tour</a>
+    </div>
+  </header>
+  <main id="snap-tour" class="snap">
+    <section class="panel panel--parallax">
+      <div class="panel__overlay">
+        <h2>Parallax Layers</h2>
+        <p>Foreground cards glide past dramatic backgrounds as you scroll. Each layer is timed to different speeds using transforms.</p>
+      </div>
+    </section>
+    <section class="panel panel--story">
+      <div class="panel__copy">
+        <h2>Sticky Storytelling</h2>
+        <p>The copy stays put while the scenery morphs underneath thanks to <code>position: sticky</code>. Perfect for product reveals.</p>
+      </div>
+      <div class="panel__scenes">
+        <div class="scene scene--one">Dream</div>
+        <div class="scene scene--two">Build</div>
+        <div class="scene scene--three">Launch</div>
+      </div>
+    </section>
+    <section class="panel panel--color">
+      <div class="panel__content">
+        <h2>Color Reveals</h2>
+        <p>Layered gradients wash over the typography as the scroll progresses. Try dragging slowly to feel the subtle animations.</p>
+      </div>
+    </section>
+    <section class="panel panel--end">
+      <div class="panel__content">
+        <h2>Made for thumbs</h2>
+        <p>Every interaction is within thumb reach, and large touch targets make the prototype feel like a polished mobile app.</p>
+        <a class="cta" href="../index.html">Back home</a>
+      </div>
+    </section>
+  </main>
+  <footer class="footer">
+    <p>CSS only. Tip: open DevTools to inspect custom properties that drive the animation.</p>
+  </footer>
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/scrolltest/script.js
+++ b/scrolltest/script.js
@@ -1,0 +1,12 @@
+(function () {
+  const updateProgress = () => {
+    const scrollable = document.documentElement.scrollHeight - window.innerHeight;
+    const scrolled = window.scrollY;
+    const progress = scrollable > 0 ? Math.min(100, Math.max(0, (scrolled / scrollable) * 100)) : 0;
+    document.body.style.setProperty('--scroll-progress', progress.toFixed(2));
+  };
+
+  updateProgress();
+  document.addEventListener('scroll', updateProgress, { passive: true });
+  window.addEventListener('resize', updateProgress);
+})();

--- a/scrolltest/styles.css
+++ b/scrolltest/styles.css
@@ -1,0 +1,269 @@
+:root {
+  --bg: #05060a;
+  --accent: #46ffba;
+  --accent-2: #5b7bff;
+  --accent-3: #ff6ec7;
+  --text: #f8f9fb;
+  --muted: #9aa3c0;
+  --scroll-progress: 0%;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Plus Jakarta Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at top, #0b1020, var(--bg));
+  color: var(--text);
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+a {
+  color: inherit;
+}
+
+.progress {
+  position: fixed;
+  inset: 0 0 auto 0;
+  height: 4px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-3));
+  transform-origin: left;
+  transform: scaleX(calc(var(--scroll-progress) / 100));
+  z-index: 1000;
+}
+
+.hero {
+  position: relative;
+  min-height: 90vh;
+  padding: 3.5rem 1.25rem 2.5rem;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  text-align: center;
+  background: linear-gradient(160deg, rgba(70, 255, 186, 0.25), rgba(91, 123, 255, 0.05) 45%, transparent 75%);
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 10% 20% auto;
+  height: 220px;
+  background: radial-gradient(circle at top, rgba(91, 123, 255, 0.4), transparent 65%);
+  filter: blur(20px);
+  z-index: -1;
+}
+
+.hero__content {
+  max-width: 540px;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  color: var(--accent);
+  font-weight: 700;
+  font-size: 0.75rem;
+}
+
+h1 {
+  font-size: clamp(2.4rem, 9vw, 3.5rem);
+  margin-bottom: 0.75rem;
+}
+
+.lede {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.cta {
+  display: inline-flex;
+  margin-top: 1.6rem;
+  padding: 0.9rem 1.6rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--accent), var(--accent-3));
+  font-weight: 600;
+  text-decoration: none;
+  letter-spacing: 0.04em;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  box-shadow: 0 20px 35px rgba(70, 255, 186, 0.2);
+}
+
+.cta:active {
+  transform: scale(0.97);
+}
+
+.snap {
+  scroll-snap-type: y mandatory;
+}
+
+.panel {
+  position: relative;
+  min-height: 100vh;
+  padding: clamp(3rem, 8vw, 5rem) 1.5rem;
+  display: grid;
+  align-items: center;
+  scroll-snap-align: start;
+  overflow: hidden;
+}
+
+.panel--parallax {
+  --bg-overlay: rgba(5, 6, 10, 0.65);
+  background:
+    radial-gradient(circle at top right, rgba(91, 123, 255, 0.35), transparent 55%),
+    url('https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=900&q=60') center / cover fixed;
+}
+
+.panel--parallax::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--bg-overlay);
+  backdrop-filter: blur(2px);
+}
+
+.panel__overlay {
+  position: relative;
+  max-width: 360px;
+  margin-inline: auto;
+  text-align: center;
+  z-index: 1;
+  padding: 2rem 1.5rem;
+  border-radius: 28px;
+  background: rgba(5, 6, 10, 0.45);
+  box-shadow: 0 40px 80px rgba(0, 0, 0, 0.35);
+}
+
+.panel--story {
+  grid-template-columns: minmax(0, 1fr);
+  background: linear-gradient(160deg, rgba(70, 255, 186, 0.12), rgba(91, 123, 255, 0.08));
+}
+
+.panel__copy {
+  position: sticky;
+  top: 10vh;
+  align-self: start;
+  padding: 1.25rem 1.5rem;
+  backdrop-filter: blur(18px);
+  background: rgba(5, 6, 10, 0.55);
+  border-radius: 22px;
+  margin-bottom: 1.5rem;
+}
+
+.panel__copy h2 {
+  margin-top: 0;
+}
+
+.panel__scenes {
+  display: grid;
+  gap: 1rem;
+}
+
+.scene {
+  height: clamp(160px, 45vh, 240px);
+  border-radius: 26px;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  font-size: 1.6rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(5, 6, 10, 0.6);
+  position: relative;
+  overflow: hidden;
+}
+
+.scene::before {
+  content: "";
+  position: absolute;
+  inset: -40% 5% 40%;
+  background: linear-gradient(120deg, transparent, rgba(255, 255, 255, 0.25), transparent);
+  transform: translateY(calc(var(--scroll-progress) * 1%));
+}
+
+.scene--one {
+  background: linear-gradient(140deg, rgba(91, 123, 255, 0.5), rgba(5, 6, 10, 0.9));
+}
+
+.scene--two {
+  background: linear-gradient(140deg, rgba(70, 255, 186, 0.5), rgba(5, 6, 10, 0.9));
+}
+
+.scene--three {
+  background: linear-gradient(140deg, rgba(255, 110, 199, 0.5), rgba(5, 6, 10, 0.9));
+}
+
+.panel--color {
+  background: radial-gradient(circle at 20% 20%, rgba(255, 110, 199, 0.65), transparent 60%),
+    radial-gradient(circle at 80% 40%, rgba(70, 255, 186, 0.7), transparent 65%),
+    radial-gradient(circle at 50% 80%, rgba(91, 123, 255, 0.55), transparent 70%),
+    #05060a;
+}
+
+.panel--color::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: conic-gradient(from calc(var(--scroll-progress) * 3.6deg), rgba(70, 255, 186, 0.15), rgba(91, 123, 255, 0.15), rgba(255, 110, 199, 0.15), rgba(70, 255, 186, 0.15));
+  mix-blend-mode: screen;
+  animation: swirl 18s linear infinite;
+}
+
+@keyframes swirl {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.panel--color .panel__content {
+  position: relative;
+  max-width: 420px;
+  margin-inline: auto;
+  text-align: center;
+  padding: 2.5rem 1.75rem;
+  backdrop-filter: blur(28px);
+  background: rgba(5, 6, 10, 0.4);
+  border-radius: 32px;
+}
+
+.panel--end {
+  background: linear-gradient(180deg, rgba(5, 6, 10, 0.7), rgba(5, 6, 10, 0.95)), url('https://images.unsplash.com/photo-1522199990976-83d6d87825a2?auto=format&fit=crop&w=900&q=60') center / cover fixed;
+}
+
+.panel--end .panel__content {
+  position: relative;
+  z-index: 1;
+  max-width: 420px;
+  margin-inline: auto;
+  text-align: center;
+  padding: 3rem 2rem;
+  border-radius: 28px;
+  background: rgba(5, 6, 10, 0.55);
+  backdrop-filter: blur(18px);
+}
+
+.footer {
+  padding: 2.5rem 1.5rem 4rem;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+code {
+  background: rgba(248, 249, 251, 0.08);
+  padding: 0.1rem 0.35rem;
+  border-radius: 6px;
+}
+
+@media (min-width: 768px) {
+  .panel--story {
+    grid-template-columns: 0.85fr 1.15fr;
+    gap: 2rem;
+  }
+
+  .panel__scenes {
+    gap: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- remove the previously-added ios-pwa directory (already merged elsewhere) so this PR no longer touches those assets
- update the homepage copy to only highlight the remaining scrolltest and HDR lab demos

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbf8e35aa8832e801214c400417424